### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git*
+docker-compose.yml


### PR DESCRIPTION
fix ERROR: failed to solve: cannot copy to non-directory: /var/lib/docker/overlay2/k1n9tutf68hssqkgt3smzhjzn/merged/usr/src/app/node_modules/@astrojs/node  FROM node:lts